### PR TITLE
Add dock manager sample with Ignite UI

### DIFF
--- a/ignite-ui-blazor-getting-started/Pages/Docking.razor
+++ b/ignite-ui-blazor-getting-started/Pages/Docking.razor
@@ -1,0 +1,66 @@
+@page "/docking"
+@using IgniteUI.Blazor.Controls
+
+<PageTitle>Dock Manager</PageTitle>
+
+<IgbDockManager Height="600px" Layout="@_layout">
+    <IgbContentPane Id="solutionExplorer" Header="Solution Explorer">
+        <p>Solution Explorer content.</p>
+    </IgbContentPane>
+    <IgbContentPane Id="properties" Header="Properties">
+        <p>Properties content.</p>
+    </IgbContentPane>
+    <IgbContentPane Id="code" Header="Program.cs">
+        <p>Code editor.</p>
+    </IgbContentPane>
+    <IgbContentPane Id="output" Header="Output">
+        <p>Build output...</p>
+    </IgbContentPane>
+</IgbDockManager>
+
+@code {
+    private IgbDockManagerLayout _layout = BuildLayout();
+
+    private static IgbDockManagerLayout BuildLayout()
+    {
+        var solution = new IgbContentPane { Id = "solutionExplorer", Header = "Solution Explorer" };
+        var properties = new IgbContentPane { Id = "properties", Header = "Properties" };
+        var code = new IgbContentPane { Id = "code", Header = "Program.cs" };
+        var output = new IgbContentPane { Id = "output", Header = "Output" };
+
+        var leftTop = new IgbTabGroupPane();
+        leftTop.Panes.Add(solution);
+
+        var leftBottom = new IgbTabGroupPane();
+        leftBottom.Panes.Add(properties);
+
+        var leftSplit = new IgbSplitPane
+        {
+            Orientation = SplitPaneOrientation.Vertical,
+            Size = 25
+        };
+        leftSplit.Panes.Add(leftTop);
+        leftSplit.Panes.Add(leftBottom);
+
+        var docGroup = new IgbTabGroupPane();
+        docGroup.Panes.Add(code);
+        docGroup.Panes.Add(output);
+
+        var docRootSplit = new IgbSplitPane();
+        docRootSplit.Panes.Add(docGroup);
+
+        var documentHost = new IgbDocumentHost
+        {
+            RootPane = docRootSplit
+        };
+
+        var root = new IgbSplitPane
+        {
+            Orientation = SplitPaneOrientation.Horizontal
+        };
+        root.Panes.Add(leftSplit);
+        root.Panes.Add(documentHost);
+
+        return new IgbDockManagerLayout { RootPane = root };
+    }
+}

--- a/ignite-ui-blazor-getting-started/Pages/_Host.cshtml
+++ b/ignite-ui-blazor-getting-started/Pages/_Host.cshtml
@@ -11,6 +11,7 @@
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
+    <link href="_content/IgniteUI.Blazor/themes/light/bootstrap.css" rel="stylesheet" />
     <link href="ignite-ui-blazor-getting-started.styles.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png"/>
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
@@ -30,5 +31,6 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
+    <script src="_content/IgniteUI.Blazor/app.bundle.js"></script>
 </body>
 </html>

--- a/ignite-ui-blazor-getting-started/Program.cs
+++ b/ignite-ui-blazor-getting-started/Program.cs
@@ -1,6 +1,7 @@
 using ignite_ui_blazor_getting_started.Data;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using IgniteUI.Blazor.Controls;
 
 // This startup file wires up services and middleware for the Blazor Server app.
 
@@ -9,6 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddIgniteUIBlazor(typeof(IgbDockManagerModule));
 // Register the forecast service via its abstraction to support testing and alternate implementations
 builder.Services.AddSingleton<IWeatherForecastService, WeatherForecastService>();
 

--- a/ignite-ui-blazor-getting-started/Shared/NavMenu.razor
+++ b/ignite-ui-blazor-getting-started/Shared/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="docking">
+                <span class="oi oi-grid-three-up" aria-hidden="true"></span> Dock Manager
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/ignite-ui-blazor-getting-started/_Imports.razor
+++ b/ignite-ui-blazor-getting-started/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using ignite_ui_blazor_getting_started
 @using ignite_ui_blazor_getting_started.Shared
+@using IgniteUI.Blazor.Controls

--- a/ignite-ui-blazor-getting-started/ignite-ui-blazor-getting-started.csproj
+++ b/ignite-ui-blazor-getting-started/ignite-ui-blazor-getting-started.csproj
@@ -7,4 +7,8 @@
     <RootNamespace>ignite_ui_blazor_getting_started</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="IgniteUI.Blazor" Version="22.2.24" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add IgniteUI.Blazor package
- configure IgniteUI in Program.cs
- include IgniteUI styles and script
- create Dock Manager demo page
- update navigation and imports

## Testing
- `dotnet build ignite-ui-blazor-getting-started/ignite-ui-blazor-getting-started.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688d0afb737c832c89a02881aa7e4dad